### PR TITLE
Add @react-cad/create-element package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-cad/core",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "lib/index.js",
   "author": "simlrh",
   "license": "LGPL",

--- a/packages/create-element/lib/cli.js
+++ b/packages/create-element/lib/cli.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+
+const cwd = process.cwd();
+const packageName = process.argv[2];
+
+if (!packageName) {
+  console.error("No package name provided. Invoke with `create-element packageName`");
+  process.exit(1);
+}
+
+function copyDir(fromPath, toPath) {
+  const filesToCreate = fs.readdirSync(fromPath);
+
+  filesToCreate.forEach(file => {
+    const origFilePath = path.join(fromPath, file);
+    const stats = fs.statSync(origFilePath);
+
+    if (stats.isFile()) {
+      const contents = fs.readFileSync(origFilePath, 'utf8');
+      const writePath = path.join(toPath, file);
+      const output = contents.replace("%PACKAGE_NAME%", packageName);
+      fs.writeFileSync(writePath, output, 'utf8');
+    } else if (stats.isDirectory()) {
+      fs.mkdirSync(path.join(toPath, file));
+      copyDir(path.join(fromPath, file), path.join(toPath, file));
+    }
+  });
+}
+
+
+const templatePath = path.join(__dirname, 'template');
+const packagePath = path.join(cwd, packageName);
+
+console.log(`Creating @react-cad element in ${packagePath}`);
+
+fs.mkdirSync(packagePath)
+copyDir(templatePath, packagePath);

--- a/packages/create-element/lib/template/.gitignore
+++ b/packages/create-element/lib/template/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+storybook-static

--- a/packages/create-element/lib/template/.storybook/main.js
+++ b/packages/create-element/lib/template/.storybook/main.js
@@ -1,0 +1,19 @@
+module.exports = {
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
+    "@storybook/addon-links",
+    "@storybook/addon-essentials",
+    "@react-cad/storybook-addon",
+  ],
+  webpackFinal: (config) => {
+    config.module.rules.push({
+      test: /react-cad-core\.wasm$/,
+      type: "javascript/auto",
+      loader: "file-loader",
+    });
+
+    config.node = { fs: "empty" };
+
+    return config;
+  },
+};

--- a/packages/create-element/lib/template/.storybook/preview.js
+++ b/packages/create-element/lib/template/.storybook/preview.js
@@ -1,0 +1,3 @@
+export const parameters = {
+  actions: { argTypesRegex: "^on[A-Z].*" },
+};

--- a/packages/create-element/lib/template/package.json
+++ b/packages/create-element/lib/template/package.json
@@ -1,23 +1,17 @@
 {
-  "name": "@react-cad/examples",
-  "version": "0.1.0",
+  "name": "%PACKAGE_NAME%",
+  "version": "1.0",
   "main": "lib/index.js",
   "license": "MIT",
-  "private": true,
   "devDependencies": {
-    "@babel/core": "^7.12.10",
     "@react-cad/renderer": "^0.1.0",
     "@react-cad/storybook-addon": "^0.1.0",
     "@storybook/addon-actions": "^6.1.11",
     "@storybook/addon-essentials": "^6.1.11",
     "@storybook/addon-links": "^6.1.11",
     "@storybook/react": "^6.1.11",
-    "babel-loader": "^8.2.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "webpack": "^5.11.1",
-    "webpack-cli": "^4.3.0",
-    "webpack-dev-server": "^3.11.1"
+    "react-dom": "^17.0.1"
   },
   "scripts": {
     "start": "start-storybook -p 6006",

--- a/packages/create-element/lib/template/src/Example.stories.tsx
+++ b/packages/create-element/lib/template/src/Example.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+
+import Example, { Props } from "./Example";
+
+const range = (from: number, to: number) => ({
+  control: {
+    type: "range",
+    min: from,
+    max: to,
+    step: 0.1,
+  },
+});
+
+const meta: Meta = {
+  title: "Example",
+  component: Example,
+  argTypes: {
+    boxSize: range(5, 15),
+    sphereSize: range(3, 10),
+  },
+};
+
+export default meta;
+
+const Template: Story<Props> = (args) => <Example {...args} />;
+
+export const example = Template.bind({});
+
+example.args = {
+  boxSize: 5,
+  sphereSize: 3.5 
+};

--- a/packages/create-element/lib/template/src/Example.tsx
+++ b/packages/create-element/lib/template/src/Example.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export interface Props {
+  boxSize: number;
+  sphereSize: number;
+}
+
+const Example: React.FunctionComponent<Props> = ({ boxSize, sphereSize }) => (
+  <difference>
+    <sphere radius={sphereSize} />
+    <translation x={-boxSize / 2} y={-boxSize / 2} z={-boxSize / 2}>
+      <box x={boxSize} y={boxSize} z={boxSize} />
+    </translation>
+  </difference>
+);
+
+export default Example;

--- a/packages/create-element/lib/template/tsconfig.json
+++ b/packages/create-element/lib/template/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules/@react-cad/renderer/types"
+    ]
+  },
+  "include": ["./src/**/*"]
+}

--- a/packages/create-element/package.json
+++ b/packages/create-element/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@react-cad/create-element",
+  "version": "0.1.0",
+  "license": "MIT",
+  "bin": {
+    "create-element": "lib/cli.js"
+  }
+}

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-cad/renderer",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -8,7 +8,7 @@
     "start": "tsc --watch --preserveWatchOutput"
   },
   "devDependencies": {
-    "@react-cad/core": "^1.0.0",
+    "@react-cad/core": "^0.1.0",
     "react": "^17.0.1",
     "react-reconciler": "^0.26.1"
   }

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -12,7 +12,7 @@ export interface Element {
   ): UpdatePayload | null;
 }
 
-export interface ElementProps {
+export interface ReactCADElements {
   box: {
     x: number;
     y: number;
@@ -30,30 +30,25 @@ export interface ElementProps {
     radius2: number;
   };
 
-  rotation: {
+  rotation: React.PropsWithChildren<{
     axis: "x" | "y" | "z";
     angle: number;
-    children?: React.ReactNode;
-  };
-  translation: {
+  }>;
+  translation: React.PropsWithChildren<{
     x: number;
     y: number;
     z: number;
-  };
-  scale: {
+  }>;
+  scale: React.PropsWithChildren<{
     factor: number;
-  };
+  }>;
 
-  union: {
-    children?: React.ReactNode;
-  };
-  difference: {
-    children?: React.ReactNode;
-  };
-  intersection: {
-    children?: React.ReactNode;
-  };
+  union: React.PropsWithChildren<unknown>;
+  difference: React.PropsWithChildren<unknown>;
+  intersection: React.PropsWithChildren<unknown>;
 }
+
+export type ElementProps = ReactCADElements;
 
 export type Container = {
   core: ReactCadCoreModule;

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-cad/storybook-addon",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "lib/preset.js",
   "files": [
@@ -19,8 +19,8 @@
     "react": "^17.0.1"
   },
   "dependencies": {
-    "@react-cad/core": "^1.0.0",
-    "@react-cad/renderer": "^1.0.0",
+    "@react-cad/core": "^0.1.0",
+    "@react-cad/renderer": "^0.1.0",
     "@storybook/addons": "^6.1.11",
     "@types/resize-observer-browser": "^0.1.4"
   },


### PR DESCRIPTION
Adds a package to generate a new react-cad project via `yarn create @react-cad/element`

addresses #16 