### PR TITLE
fix(packages/storybook-addon): free core heap on canvas unmount

### DIFF
--- a/packages/core/src/CMakeLists.txt
+++ b/packages/core/src/CMakeLists.txt
@@ -39,12 +39,13 @@ target_link_libraries(
 set_target_properties(${APP_TARGET} PROPERTIES LINK_FLAGS "\
   --bind \
   -s EXTRA_EXPORTED_RUNTIME_METHODS=['FS','ccall','cwrap'] \
+  -s EXPORTED_FUNCTIONS=['_main','_shutdown'] \
   -s WASM=1 \
   -s MODULARIZE=1 \
   -s USE_WEBGL2=1 \
   -s USE_FREETYPE=1 \
   -s ALLOW_MEMORY_GROWTH=1 \
-  -s NO_EXIT_RUNTIME=1 \
+  -s EXIT_RUNTIME=1 \
 ")
 
 add_custom_command(

--- a/packages/core/src/ReactCADView.cpp
+++ b/packages/core/src/ReactCADView.cpp
@@ -75,6 +75,11 @@ std::shared_ptr<ReactCADView> ReactCADView::getView()
   return singleton;
 }
 
+void ReactCADView::destroyView()
+{
+  singleton = nullptr;
+}
+
 ReactCADView::ReactCADView() : myDevicePixelRatio(jsDevicePixelRatio()), myUpdateRequests(0)
 {
 

--- a/packages/core/src/ReactCADView.h
+++ b/packages/core/src/ReactCADView.h
@@ -44,6 +44,7 @@ class ReactCADView : protected AIS_ViewController
 {
 public:
   static std::shared_ptr<ReactCADView> getView();
+  static void destroyView();
 
   //! Destructor.
   virtual ~ReactCADView();

--- a/packages/core/src/main.cpp
+++ b/packages/core/src/main.cpp
@@ -134,6 +134,12 @@ int main()
   return 0;
 }
 
+extern "C" void shutdown()
+{
+  ReactCADView::destroyView();
+  emscripten_force_exit(0);
+}
+
 namespace emscripten
 {
 namespace internal

--- a/packages/core/src/react-cad-core.d.ts
+++ b/packages/core/src/react-cad-core.d.ts
@@ -133,6 +133,7 @@ export interface ReactCADCore extends EmscriptenModule {
     readFile(path: string, opts?: { flags?: string }): Uint8Array;
     unlink(path: string): void;
   };
+  _shutdown(): void;
 }
 
 declare const reactCadCore: EmscriptenModuleFactory<ReactCADCore>;


### PR DESCRIPTION
closes #26 

Adds a function to core which destroys the view and exits emscripten
Preview component calls this function when the canvas element unmounts